### PR TITLE
Upgrade to v1.16.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ It shall NOT be edited by hand.
 Dagu is a powerful Cron alternative that comes with a Web UI. It allows you to define dependencies between commands as a Directed Acyclic Graph (DAG) in a declarative YAML format. Dagu simplifies the management and execution of complex workflows. It natively supports running Docker containers, making HTTP requests, and executing commands over SSH.
 
 
-**Shipped version:** 1.16.2~ynh1
+**Shipped version:** 1.16.3~ynh1
 
 ## Screenshots
 

--- a/README_es.md
+++ b/README_es.md
@@ -21,7 +21,7 @@ No se debe editar a mano.
 Dagu is a powerful Cron alternative that comes with a Web UI. It allows you to define dependencies between commands as a Directed Acyclic Graph (DAG) in a declarative YAML format. Dagu simplifies the management and execution of complex workflows. It natively supports running Docker containers, making HTTP requests, and executing commands over SSH.
 
 
-**Versión actual:** 1.16.2~ynh1
+**Versión actual:** 1.16.3~ynh1
 
 ## Capturas
 

--- a/README_eu.md
+++ b/README_eu.md
@@ -21,7 +21,7 @@ EZ editatu eskuz.
 Dagu is a powerful Cron alternative that comes with a Web UI. It allows you to define dependencies between commands as a Directed Acyclic Graph (DAG) in a declarative YAML format. Dagu simplifies the management and execution of complex workflows. It natively supports running Docker containers, making HTTP requests, and executing commands over SSH.
 
 
-**Paketatutako bertsioa:** 1.16.2~ynh1
+**Paketatutako bertsioa:** 1.16.3~ynh1
 
 ## Pantaila-argazkiak
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -21,7 +21,7 @@ Il NE doit PAS être modifié à la main.
 Dagu est une alternative puissante à Cron qui est fournie avec une interface utilisateur Web. Il vous permet de définir des dépendances entre les commandes sous forme de graphe acyclique dirigé (DAG) dans un format YAML déclaratif. Dagu simplifie la gestion et l'exécution de flux de travail complexes. Il prend en charge nativement l'exécution de conteneurs Docker, la création de requêtes HTTP et l'exécution de commandes via SSH.
 
 
-**Version incluse :** 1.16.2~ynh1
+**Version incluse :** 1.16.3~ynh1
 
 ## Captures d’écran
 

--- a/README_gl.md
+++ b/README_gl.md
@@ -21,7 +21,7 @@ NON debe editarse manualmente.
 Dagu is a powerful Cron alternative that comes with a Web UI. It allows you to define dependencies between commands as a Directed Acyclic Graph (DAG) in a declarative YAML format. Dagu simplifies the management and execution of complex workflows. It natively supports running Docker containers, making HTTP requests, and executing commands over SSH.
 
 
-**Versión proporcionada:** 1.16.2~ynh1
+**Versión proporcionada:** 1.16.3~ynh1
 
 ## Capturas de pantalla
 

--- a/README_id.md
+++ b/README_id.md
@@ -21,7 +21,7 @@ Ini TIDAK boleh diedit dengan tangan.
 Dagu is a powerful Cron alternative that comes with a Web UI. It allows you to define dependencies between commands as a Directed Acyclic Graph (DAG) in a declarative YAML format. Dagu simplifies the management and execution of complex workflows. It natively supports running Docker containers, making HTTP requests, and executing commands over SSH.
 
 
-**Versi terkirim:** 1.16.2~ynh1
+**Versi terkirim:** 1.16.3~ynh1
 
 ## Tangkapan Layar
 

--- a/README_nl.md
+++ b/README_nl.md
@@ -21,7 +21,7 @@ Hij mag NIET handmatig aangepast worden.
 Dagu is a powerful Cron alternative that comes with a Web UI. It allows you to define dependencies between commands as a Directed Acyclic Graph (DAG) in a declarative YAML format. Dagu simplifies the management and execution of complex workflows. It natively supports running Docker containers, making HTTP requests, and executing commands over SSH.
 
 
-**Geleverde versie:** 1.16.2~ynh1
+**Geleverde versie:** 1.16.3~ynh1
 
 ## Schermafdrukken
 

--- a/README_pl.md
+++ b/README_pl.md
@@ -21,7 +21,7 @@ Nie powinno być ono edytowane ręcznie.
 Dagu is a powerful Cron alternative that comes with a Web UI. It allows you to define dependencies between commands as a Directed Acyclic Graph (DAG) in a declarative YAML format. Dagu simplifies the management and execution of complex workflows. It natively supports running Docker containers, making HTTP requests, and executing commands over SSH.
 
 
-**Dostarczona wersja:** 1.16.2~ynh1
+**Dostarczona wersja:** 1.16.3~ynh1
 
 ## Zrzuty ekranu
 

--- a/README_ru.md
+++ b/README_ru.md
@@ -21,7 +21,7 @@
 Dagu is a powerful Cron alternative that comes with a Web UI. It allows you to define dependencies between commands as a Directed Acyclic Graph (DAG) in a declarative YAML format. Dagu simplifies the management and execution of complex workflows. It natively supports running Docker containers, making HTTP requests, and executing commands over SSH.
 
 
-**Поставляемая версия:** 1.16.2~ynh1
+**Поставляемая версия:** 1.16.3~ynh1
 
 ## Снимки экрана
 

--- a/README_zh_Hans.md
+++ b/README_zh_Hans.md
@@ -21,7 +21,7 @@
 Dagu is a powerful Cron alternative that comes with a Web UI. It allows you to define dependencies between commands as a Directed Acyclic Graph (DAG) in a declarative YAML format. Dagu simplifies the management and execution of complex workflows. It natively supports running Docker containers, making HTTP requests, and executing commands over SSH.
 
 
-**分发版本：** 1.16.2~ynh1
+**分发版本：** 1.16.3~ynh1
 
 ## 截图
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -9,7 +9,7 @@ description.fr = "Alternative à Cron fournie avec une interface utilisateur Web
 
 version = "1.16.2~ynh1"
 
-maintainers = ["eric_G"]
+maintainers = []
 
 [upstream]
 license = "GPL-3.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Dagu"
 description.en = "Cron alternative that comes with a Web UI"
 description.fr = "Alternative à Cron fournie avec une interface utilisateur Web"
 
-version = "1.16.2~ynh1"
+version = "1.16.3~ynh1"
 
 maintainers = []
 
@@ -43,12 +43,12 @@ ram.runtime = "50M"
 
     [resources.sources.main]
     in_subdir = false
-    amd64.url = "https://github.com/dagu-org/dagu/releases/download/v1.16.2/dagu_1.16.2_linux_amd64.tar.gz"
-    amd64.sha256 = "b9bdc081c345efefe97ce17c6b4e22b3a81e672e2e2e77b4ae9be18ab6eb6bd5"
-    arm64.url = "https://github.com/dagu-org/dagu/releases/download/v1.16.2/dagu_1.16.2_linux_arm64.tar.gz"
-    arm64.sha256 = "e353b000710cf54801b3b6e8638ecd471e7be868a8299671703b8170d5131ec4"
-    armhf.url = "https://github.com/dagu-org/dagu/releases/download/v1.16.2/dagu_1.16.2_linux_armv7.tar.gz"
-    armhf.sha256 = "e166f87578bd8d474f478dc0e9d4ae6d4ccdd9918159db3d01fc78494db26a03"
+    amd64.url = "https://github.com/dagu-org/dagu/releases/download/v1.16.3/dagu_1.16.3_linux_amd64.tar.gz"
+    amd64.sha256 = "baf4a3db10e7523b3685ddcaa92d51d8e15107e9064ba2cf164590dc5161cc99"
+    arm64.url = "https://github.com/dagu-org/dagu/releases/download/v1.16.3/dagu_1.16.3_linux_arm64.tar.gz"
+    arm64.sha256 = "4d532c028ea5f7f79c825ec52577fcdcddbbf06c3bcbd635ea6b5e88d91509f3"
+    armhf.url = "https://github.com/dagu-org/dagu/releases/download/v1.16.3/dagu_1.16.3_linux_armv7.tar.gz"
+    armhf.sha256 = "6fdf285476ee8a803277d96758e28e57bd0658ababe120821b8b5cc5c9b615cc"
 
     autoupdate.strategy = "latest_github_release"
     autoupdate.asset.amd64 = "^dagu_.*_linux_amd64.tar.gz$"


### PR DESCRIPTION
Upgrade sources
- `main` v1.16.3: https://github.com/dagu-org/dagu/releases/tag/v1.16.3

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
