### PR TITLE
Upgrade to v1.16.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ It shall NOT be edited by hand.
 Dagu is a powerful Cron alternative that comes with a Web UI. It allows you to define dependencies between commands as a Directed Acyclic Graph (DAG) in a declarative YAML format. Dagu simplifies the management and execution of complex workflows. It natively supports running Docker containers, making HTTP requests, and executing commands over SSH.
 
 
-**Shipped version:** 1.16.5~ynh1
+**Shipped version:** 1.16.6~ynh1
 
 ## Screenshots
 

--- a/README_es.md
+++ b/README_es.md
@@ -21,7 +21,7 @@ No se debe editar a mano.
 Dagu is a powerful Cron alternative that comes with a Web UI. It allows you to define dependencies between commands as a Directed Acyclic Graph (DAG) in a declarative YAML format. Dagu simplifies the management and execution of complex workflows. It natively supports running Docker containers, making HTTP requests, and executing commands over SSH.
 
 
-**Versión actual:** 1.16.5~ynh1
+**Versión actual:** 1.16.6~ynh1
 
 ## Capturas
 

--- a/README_eu.md
+++ b/README_eu.md
@@ -21,7 +21,7 @@ EZ editatu eskuz.
 Dagu is a powerful Cron alternative that comes with a Web UI. It allows you to define dependencies between commands as a Directed Acyclic Graph (DAG) in a declarative YAML format. Dagu simplifies the management and execution of complex workflows. It natively supports running Docker containers, making HTTP requests, and executing commands over SSH.
 
 
-**Paketatutako bertsioa:** 1.16.5~ynh1
+**Paketatutako bertsioa:** 1.16.6~ynh1
 
 ## Pantaila-argazkiak
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -21,7 +21,7 @@ Il NE doit PAS être modifié à la main.
 Dagu est une alternative puissante à Cron qui est fournie avec une interface utilisateur Web. Il vous permet de définir des dépendances entre les commandes sous forme de graphe acyclique dirigé (DAG) dans un format YAML déclaratif. Dagu simplifie la gestion et l'exécution de flux de travail complexes. Il prend en charge nativement l'exécution de conteneurs Docker, la création de requêtes HTTP et l'exécution de commandes via SSH.
 
 
-**Version incluse :** 1.16.5~ynh1
+**Version incluse :** 1.16.6~ynh1
 
 ## Captures d’écran
 

--- a/README_gl.md
+++ b/README_gl.md
@@ -21,7 +21,7 @@ NON debe editarse manualmente.
 Dagu is a powerful Cron alternative that comes with a Web UI. It allows you to define dependencies between commands as a Directed Acyclic Graph (DAG) in a declarative YAML format. Dagu simplifies the management and execution of complex workflows. It natively supports running Docker containers, making HTTP requests, and executing commands over SSH.
 
 
-**Versión proporcionada:** 1.16.5~ynh1
+**Versión proporcionada:** 1.16.6~ynh1
 
 ## Capturas de pantalla
 

--- a/README_id.md
+++ b/README_id.md
@@ -21,7 +21,7 @@ Ini TIDAK boleh diedit dengan tangan.
 Dagu is a powerful Cron alternative that comes with a Web UI. It allows you to define dependencies between commands as a Directed Acyclic Graph (DAG) in a declarative YAML format. Dagu simplifies the management and execution of complex workflows. It natively supports running Docker containers, making HTTP requests, and executing commands over SSH.
 
 
-**Versi terkirim:** 1.16.5~ynh1
+**Versi terkirim:** 1.16.6~ynh1
 
 ## Tangkapan Layar
 

--- a/README_nl.md
+++ b/README_nl.md
@@ -21,7 +21,7 @@ Hij mag NIET handmatig aangepast worden.
 Dagu is a powerful Cron alternative that comes with a Web UI. It allows you to define dependencies between commands as a Directed Acyclic Graph (DAG) in a declarative YAML format. Dagu simplifies the management and execution of complex workflows. It natively supports running Docker containers, making HTTP requests, and executing commands over SSH.
 
 
-**Geleverde versie:** 1.16.5~ynh1
+**Geleverde versie:** 1.16.6~ynh1
 
 ## Schermafdrukken
 

--- a/README_pl.md
+++ b/README_pl.md
@@ -21,7 +21,7 @@ Nie powinno być ono edytowane ręcznie.
 Dagu is a powerful Cron alternative that comes with a Web UI. It allows you to define dependencies between commands as a Directed Acyclic Graph (DAG) in a declarative YAML format. Dagu simplifies the management and execution of complex workflows. It natively supports running Docker containers, making HTTP requests, and executing commands over SSH.
 
 
-**Dostarczona wersja:** 1.16.5~ynh1
+**Dostarczona wersja:** 1.16.6~ynh1
 
 ## Zrzuty ekranu
 

--- a/README_ru.md
+++ b/README_ru.md
@@ -21,7 +21,7 @@
 Dagu is a powerful Cron alternative that comes with a Web UI. It allows you to define dependencies between commands as a Directed Acyclic Graph (DAG) in a declarative YAML format. Dagu simplifies the management and execution of complex workflows. It natively supports running Docker containers, making HTTP requests, and executing commands over SSH.
 
 
-**Поставляемая версия:** 1.16.5~ynh1
+**Поставляемая версия:** 1.16.6~ynh1
 
 ## Снимки экрана
 

--- a/README_zh_Hans.md
+++ b/README_zh_Hans.md
@@ -21,7 +21,7 @@
 Dagu is a powerful Cron alternative that comes with a Web UI. It allows you to define dependencies between commands as a Directed Acyclic Graph (DAG) in a declarative YAML format. Dagu simplifies the management and execution of complex workflows. It natively supports running Docker containers, making HTTP requests, and executing commands over SSH.
 
 
-**分发版本：** 1.16.5~ynh1
+**分发版本：** 1.16.6~ynh1
 
 ## 截图
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Dagu"
 description.en = "Cron alternative that comes with a Web UI"
 description.fr = "Alternative à Cron fournie avec une interface utilisateur Web"
 
-version = "1.16.5~ynh1"
+version = "1.16.6~ynh1"
 
 maintainers = []
 
@@ -43,12 +43,12 @@ ram.runtime = "50M"
 
     [resources.sources.main]
     in_subdir = false
-    amd64.url = "https://github.com/dagu-org/dagu/releases/download/v1.16.5/dagu_1.16.5_linux_amd64.tar.gz"
-    amd64.sha256 = "552f7ea21a7f5d4c938b2b48f68126097b0f98d050ff703f0d8267ecea0cb730"
-    arm64.url = "https://github.com/dagu-org/dagu/releases/download/v1.16.5/dagu_1.16.5_linux_arm64.tar.gz"
-    arm64.sha256 = "c34123f19271850ea0b9e50c3db3ad53ee6383651fb3fb9a485af491b8064ca2"
-    armhf.url = "https://github.com/dagu-org/dagu/releases/download/v1.16.5/dagu_1.16.5_linux_armv7.tar.gz"
-    armhf.sha256 = "b823ac6f77d4a60081e3c1159193762b695e3a42831b09e9b3a845cc4579dd8e"
+    amd64.url = "https://github.com/dagu-org/dagu/releases/download/v1.16.6/dagu_1.16.6_linux_amd64.tar.gz"
+    amd64.sha256 = "c02c34454606bca9a38652a3aacf0df2cedbd94478d7bbebd2a21cf56bb6b33b"
+    arm64.url = "https://github.com/dagu-org/dagu/releases/download/v1.16.6/dagu_1.16.6_linux_arm64.tar.gz"
+    arm64.sha256 = "3b9b4504bfd8277a99072c28b72b23d99cb1a16c6b400120b7236b82ff8e9c2b"
+    armhf.url = "https://github.com/dagu-org/dagu/releases/download/v1.16.6/dagu_1.16.6_linux_armv7.tar.gz"
+    armhf.sha256 = "41d7473a3683bf14ab3d3fcdc1fd1b9be8be50378ca8a3a63841f1dc1a02140a"
 
     autoupdate.strategy = "latest_github_release"
     autoupdate.asset.amd64 = "^dagu_.*_linux_amd64.tar.gz$"


### PR DESCRIPTION
Upgrade sources
- `main` v1.16.6: https://github.com/dagu-org/dagu/releases/tag/v1.16.6

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
