### PR TITLE
store DAGs in __DATA_DIR__

### DIFF
--- a/conf/.env
+++ b/conf/.env
@@ -1,5 +1,5 @@
 DAGU_HOST=127.0.0.1
 DAGU_PORT=__PORT__
 DAGU_TZ=__TIMEZONE__
-DAGU_DAGS_DIR=__INSTALL_DIR__/.config/dagu/dags
+DAGU_DAGS_DIR=__DATA_DIR__/dags
 DAGU_BASE_CONFIG=__INSTALL_DIR__/.config/dagu/config.yaml

--- a/conf/scheduler.service
+++ b/conf/scheduler.service
@@ -8,7 +8,7 @@ User=__APP__
 Group=__APP__
 EnvironmentFile=__INSTALL_DIR__/.env
 WorkingDirectory=__INSTALL_DIR__/
-ExecStart=__INSTALL_DIR__/dagu scheduler
+ExecStart=__INSTALL_DIR__/dagu scheduler --dags=__DATA_DIR__/dags
 StandardOutput=append:/var/log/__APP__/__APP__-scheduler.log
 StandardError=inherit
 

--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -8,7 +8,7 @@ User=__APP__
 Group=__APP__
 EnvironmentFile=__INSTALL_DIR__/.env
 WorkingDirectory=__INSTALL_DIR__/
-ExecStart=__INSTALL_DIR__/dagu server
+ExecStart=__INSTALL_DIR__/dagu server --dags=__DATA_DIR__/dags
 StandardOutput=append:/var/log/__APP__/__APP__.log
 StandardError=inherit
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -59,6 +59,8 @@ ram.runtime = "50M"
 
     [resources.install_dir]
 
+    [resources.data_dir]
+
     [resources.permissions]
     main.url = "/"
 

--- a/scripts/backup
+++ b/scripts/backup
@@ -17,6 +17,12 @@ ynh_print_info "Declaring files to be backed up..."
 ynh_backup "$install_dir"
 
 #=================================================
+# BACKUP THE DATA DIR
+#=================================================
+
+ynh_backup "$data_dir"
+
+#=================================================
 # BACKUP SYSTEM CONFIGURATION
 #=================================================
 

--- a/scripts/restore
+++ b/scripts/restore
@@ -22,8 +22,6 @@ ynh_script_progression --message="Restoring the data directory..."
 
 ynh_restore "$data_dir"
 
-chown -R $app:$app "$data_dir"
-
 #=================================================
 # RESTORE SYSTEM CONFIGURATIONS
 #=================================================

--- a/scripts/restore
+++ b/scripts/restore
@@ -16,6 +16,15 @@ ynh_script_progression "Restoring the app main directory..."
 ynh_restore "$install_dir"
 
 #=================================================
+# RESTORE THE DATA DIRECTORY
+#=================================================
+ynh_script_progression --message="Restoring the data directory..."
+
+ynh_restore "$data_dir"
+
+chown -R $app:$app "$data_dir"
+
+#=================================================
 # RESTORE SYSTEM CONFIGURATIONS
 #=================================================
 ynh_script_progression "Restoring system configurations related to $app..."


### PR DESCRIPTION
## Problem

- Today, the DAGs (the description of the jobs to be executed by Dagu) are stored in `__INSTALL_DIR__/.config/dagu/dags`, next to the application and its configuration.
- This can be an issue because this means that the jobs are managed as a part of the application itself:
  - they are removed when you remove the application
  - they are backup and restored with the application
  - ...
- I think that the jobs shall be considered a data and, as such, not being so strongly linked to the application lifecycle.

## Solution

- As it is already done for other apps (ex: Nextcloud, Syncthing, Silverbullet, ...), my proposition is to store the DAGs in the `__DATA_DIR__/dags` directory.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
